### PR TITLE
Fix(usage): don't print defaults of required positionals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1193,7 +1193,8 @@ impl Parser {
         if self.wants_help() {
             let def = into.to_string();
             self.printer.add_positional(printer::Positional::new(
-                name, desc, if def.is_empty() { None } else { Some(def) },
+                name, desc,
+                if def.is_empty() || required { None } else { Some(def) },
                 required, false
             ))?;
             return Ok(self);


### PR DESCRIPTION
Hi! Nice library :)

Sending you a oneliner patch, hopefully trivial enough to review & merge in 2 clicks.

See, if I'm doing a (non-optional!) positional argument, the help message comes out a little awkward, `[required, default: 0]`:
```
usage: foobar [-S UINT64] n

options:
    -S, --seed UINT64        RNG seed to start from [default: 8214974914043046976]

positionals:
    n                        permutation length [required, default: 0]
```

It kind of makes no sense to talk about defaults of args the user can't omit.


